### PR TITLE
Adds support for generating type codenames as string constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Go to folder where you want to create models and run:
 
 You may specify other options like:
 
-`kontent-generate --projectId=xxx --addTimestamp=false --nameResolver=camelCase`
+`kontent-generate --projectId=xxx --addTimestamp=false --nameResolver=camelCase --includeCodename=true`
 
 ## Generate models in code
 
@@ -33,6 +33,7 @@ await generateModelsAsync({
     projectId: 'da5abe9f-fdad-4168-97cd-b3464be2ccb9',
     addTimestamp: true,
     nameResolver: 'camelCase',
+    includeCodename: true,
 })
 ```
 
@@ -42,6 +43,7 @@ await generateModelsAsync({
 - `secureAccessKey`- Secure API Key if your Kontent project has secure mode enabled
 - `addTimestamp`- Indicates if timestamp is added to generated models
 - `nameResolver`- Name resolver for elements. Available options are: `camelCase`, `pascalCase`, `snakeCase`
+- `includeCodename` - If true, the generated classes will also contain constant with type codename
 
 ## Example models
 
@@ -81,6 +83,8 @@ export type Actor = IContentItem<{
   lastName: Elements.TextElement;
   photo: Elements.AssetsElement;
 }>;
+
+export const Actor_CODENAME: string = "actor";
 
 ```
 

--- a/lib/cli/cli.ts
+++ b/lib/cli/cli.ts
@@ -10,6 +10,7 @@ const projectId = argv.projectId;
 const secureAccessKey = argv.secureAccessKey;
 const addTimestamp = argv.addTimestamp;
 const nameResolver = argv.nameResolver;
+const includeCodename = argv.includeCodename;
 
 if (!projectId) {
     throw Error(`Please provide project id using 'projectId' argument`);
@@ -21,6 +22,7 @@ const run = async () => {
         secureAccessKey: secureAccessKey,
         addTimestamp: addTimestamp === 'true' ? true : false,
         nameResolver: nameResolver,
+        includeCodename: includeCodename === 'true' ? true : false,
         formatOptions: undefined
     });
 };

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -48,6 +48,7 @@ function generateClass(type: IContentType, config: IGenerateModelsConfig): void 
         addTimestamp: config.addTimestamp,
         formatOptions: config.formatOptions,
         nameResolver: config.nameResolver,
+        includeCodename: config.includeCodename,
         customNameResolver: config.customNameResolver
     });
 

--- a/lib/model-helper.ts
+++ b/lib/model-helper.ts
@@ -20,9 +20,10 @@ export class ModelHelper {
         addTimestamp: boolean;
         formatOptions?: Options;
         nameResolver?: PropertyNameResolverType;
+        includeCodename: boolean;
         customNameResolver?: PropertyNameResolver;
     }): string {
-        const code = `
+        let code = `
 import { IContentItem, Elements } from '@kentico/kontent-delivery';
 
 /**
@@ -36,6 +37,13 @@ export type ${this.capitalize(data.type.system.codename)} = IContentItem<{
     })}
 }>;
 `;
+
+        if (data.includeCodename) {
+            code += `
+export const ${this.capitalize(data.type.system.codename)}_CODENAME: string = "${data.type.system.codename}";
+`;
+        }
+
         const formatOptions: Options = data.formatOptions
             ? data.formatOptions
             : {

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -8,6 +8,7 @@ export interface IGenerateModelsConfig {
     addTimestamp: boolean;
     secureAccessKey?: string;
     nameResolver?: PropertyNameResolverType;
+    includeCodename: boolean;
     formatOptions?: Options;
     customNameResolver?: PropertyNameResolver;
 }


### PR DESCRIPTION
### Motivation

Adds support for generating type codenames as string constants

### Checklist

- [X] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [X] Tests are passing
- [X] Docs have been updated (if applicable)
- [X] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Run the model generator with flag --includeCodename=true and the generated models contain string literal with type codename.
