### PR TITLE
Changes languages in project structure to array

### DIFF
--- a/lib/generators/delivery/delivery-project.generator.ts
+++ b/lib/generators/delivery/delivery-project.generator.ts
@@ -35,9 +35,9 @@ export class DeliveryProjectGenerator {
 * ${commonHelper.getAutogenerateNote(data.addTimestamp)}
 */
 export const projectModel = {
-    languages: {
+    languages: [
         ${this.getProjectLanguages(data.languages)}
-    },
+    ],
     contentTypes: {
         ${this.getProjectContentTypes(data.types)}
     },
@@ -63,7 +63,7 @@ export const projectModel = {
         for (let i = 0; i < languages.length; i++) {
             const language = languages[i];
             const isLast = i === languages.length - 1;
-            code += `${language.system.codename}: {
+            code += `{
                 codename: '${language.system.codename}',
                 name: '${commonHelper.escapeNameValue(language.system.name)}'}
             ${!isLast ? ',' : ''}`;


### PR DESCRIPTION
### Motivation

Language codenames may contain characters that are not valid when used as JSON keys. Typically, it's the ISO representations of languages:

* cs-CZ
* en-US

And others. The generated project structure used language codenames as object keys which led to invalid JSON project structure:

```
export const projectModel = {
  languages: {
    cs-CZ: {
      codename: 'cs-CZ',
      name: 'Czech',
    },
    en-US: {
      codename: 'en-US',
      name: 'Default project language',
    },
  },
```

This PR adjusts the languages part of project structure to array - easily filterable using `Array.find` by the codename property.